### PR TITLE
LG-1988 Accept Arabic numbers

### DIFF
--- a/PhoneNumberKit/ParseManager.swift
+++ b/PhoneNumberKit/ParseManager.swift
@@ -37,7 +37,7 @@ final class ParseManager {
         // Convert number to latin
         var latinNumberString = numberString
         if #available(iOSApplicationExtension 9.0, *) {
-            latinNumberString = numberString.applyingTransform(StringTransform.toLatin, reverse: false) ?? numberString
+            latinNumberString = numberString.applyingTransform(.toLatin, reverse: false) ?? numberString
         }
 
         var nationalNumber = latinNumberString

--- a/PhoneNumberKit/ParseManager.swift
+++ b/PhoneNumberKit/ParseManager.swift
@@ -34,12 +34,17 @@ final class ParseManager {
         let region = region.uppercased()
         // Extract number (2)
 
-        var nationalNumber = numberString
+        // Convert number to latin
+        var latinNumberString = numberString
+        if #available(iOSApplicationExtension 9.0, *) {
+            latinNumberString = numberString.applyingTransform(StringTransform.toLatin, reverse: false) ?? numberString
+        }
 
-        let match = try regexManager.phoneDataDetectorMatch(numberString)
+        var nationalNumber = latinNumberString
+
+        let match = try regexManager.phoneDataDetectorMatch(latinNumberString)
         let matchedNumber = nationalNumber.substring(with: match.range)
-        // Replace Arabic and Persian numerals and let the rest unchanged
-        nationalNumber = regexManager.stringByReplacingOccurrences(matchedNumber, map: PhoneNumberPatterns.allNormalizationMappings, keepUnmapped: true)
+        nationalNumber = matchedNumber
 
         // Strip and extract extension (3)
         var numberExtension: String?
@@ -93,7 +98,7 @@ final class ParseManager {
             }
         }
 
-        let phoneNumber = PhoneNumber(numberString: numberString, countryCode: countryCode, leadingZero: leadingZero, nationalNumber: finalNationalNumber, numberExtension: numberExtension, type: type, regionID: regionMetadata.codeID)
+        let phoneNumber = PhoneNumber(numberString: latinNumberString, countryCode: countryCode, leadingZero: leadingZero, nationalNumber: finalNationalNumber, numberExtension: numberExtension, type: type, regionID: regionMetadata.codeID)
         return phoneNumber
     }
 

--- a/PhoneNumberKit/ParseManager.swift
+++ b/PhoneNumberKit/ParseManager.swift
@@ -36,7 +36,7 @@ final class ParseManager {
 
         // Convert number to latin
         var latinNumberString = numberString
-        if #available(iOSApplicationExtension 9.0, *) {
+        if #available(iOS 9.0, *) {
             latinNumberString = numberString.applyingTransform(.toLatin, reverse: false) ?? numberString
         }
 

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -100,7 +100,7 @@ public final class PartialFormatter {
         // Convert number to latin
         var latinRawNumber = rawNumber
         if #available(iOSApplicationExtension 9.0, *) {
-            latinRawNumber = rawNumber.applyingTransform(StringTransform.toLatin, reverse: false) ?? rawNumber
+            latinRawNumber = rawNumber.applyingTransform(.toLatin, reverse: false) ?? rawNumber
         }
 
         // Always reset variables with each new raw number
@@ -141,7 +141,7 @@ public final class PartialFormatter {
         finalNumber.append(split.pausesOrWaits)
         if containsArabic {
             if #available(iOSApplicationExtension 9.0, *) {
-                finalNumber = finalNumber.applyingTransform(StringTransform.latinToArabic, reverse: false) ?? finalNumber
+                finalNumber = finalNumber.applyingTransform(.latinToArabic, reverse: false) ?? finalNumber
             }
         }
         return finalNumber

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -99,7 +99,7 @@ public final class PartialFormatter {
 
         // Convert number to latin
         var latinRawNumber = rawNumber
-        if #available(iOSApplicationExtension 9.0, *) {
+        if #available(iOS 9.0, *) {
             latinRawNumber = rawNumber.applyingTransform(.toLatin, reverse: false) ?? rawNumber
         }
 
@@ -107,7 +107,7 @@ public final class PartialFormatter {
         self.resetVariables()
 
         guard self.isValidRawNumber(latinRawNumber) else {
-            return latinRawNumber
+            return rawNumber
         }
         let split = splitNumberAndPausesOrWaits(latinRawNumber)
         
@@ -139,10 +139,8 @@ public final class PartialFormatter {
             finalNumber = String(finalNumber[..<finalNumber.index(before: finalNumber.endIndex)])
         }
         finalNumber.append(split.pausesOrWaits)
-        if containsArabic {
-            if #available(iOSApplicationExtension 9.0, *) {
-                finalNumber = finalNumber.applyingTransform(.latinToArabic, reverse: false) ?? finalNumber
-            }
+        if containsArabic, #available(iOS 9.0, *) {
+            finalNumber = finalNumber.applyingTransform(.latinToArabic, reverse: false) ?? finalNumber
         }
         return finalNumber
     }


### PR DESCRIPTION
With these changes, numbers in Arabic will be validated and formatted.
If there's a single Arabic number in the string, all numbers are converted to Arabic.
Converting any number to latin is easy, but converting each part of the string back to the original script would be much challenging, specially because the string changes after all the formatting, so we can't use index.